### PR TITLE
Remove dependencies on ros_control and ros_controllers metapackages.

### DIFF
--- a/vulcano_base_control/package.xml
+++ b/vulcano_base_control/package.xml
@@ -9,12 +9,15 @@
   <maintainer email="info@robotnik.es">Robotnik</maintainer>
 
   <license>BSD</license>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
-  
-  <run_depend>ros_controllers</run_depend>
-  <run_depend>ros_control</run_depend>
+
+  <run_depend>controller_manager</run_depend>
+  <run_depend>joint_state_controller</run_depend>
+  <run_depend>omni_drive_controller</run_depend>
+  <run_depend>position_controllers</run_depend>
   <run_depend>robot_state_publisher</run_depend>
-  <!-- run_depend>vulcano_base_pad</run_depend -->   
+  <run_depend>velocity_controllers</run_depend>
+  <!-- run_depend>vulcano_base_pad</run_depend -->
 
 </package>


### PR DESCRIPTION
As per http://www.ros.org/reps/rep-0127.html, packages are not allowed to
depend on metapackages.