### PR TITLE
Fix deps

### DIFF
--- a/vulcano_common/package.xml
+++ b/vulcano_common/package.xml
@@ -11,13 +11,23 @@
   <author email="info@robotnik.es">Robotnik</author>
 
   <maintainer email="info@robotnik.es">Robotnik</maintainer>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
 
+  <run_depend>vulcano_arm_control</run_depend>
+  <run_depend>vulcano_base_bringup</run_depend>
+  <run_depend>vulcano_base_control</run_depend>
+  <run_depend>vulcano_base_description</run_depend>
+  <run_depend>vulcano_base_navigation</run_depend>
+  <run_depend>vulcano_base_pad</run_depend>
+  <run_depend>vulcano_bringup</run_depend>
   <run_depend>vulcano_description</run_depend>
-  <run_depend>vulcano_torso_description</run_depend>
-  <run_depend>vulcano_pad_description</run_depend>
   <run_depend>vulcano_moveit_config</run_depend>
+  <run_depend>vulcano_sim_bringup</run_depend>
+  <run_depend>vulcano_torso_control</run_depend>
+  <run_depend>vulcano_torso_description</run_depend>
+  <run_depend>vulcano_torso_pad</run_depend>
+  <run_depend>vulcano_web</run_depend>
 
   <export>
     <metapackage/>

--- a/vulcano_web/package.xml
+++ b/vulcano_web/package.xml
@@ -4,7 +4,7 @@
   <version>0.0.1</version>
   <description>A simple web server for the Vulcano robot </description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
   <!-- Example:  -->
   <maintainer email="rguzman@robotnik.es">Robert</maintainer>
 
@@ -35,12 +35,11 @@
   <run_depend>tf</run_depend>
   <run_depend>gazebo_ros</run_depend>
   <run_depend>rosbridge_server</run_depend>
-  <run_depend>mjpeg_server</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>cv_bridge</run_depend>
 
- 
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
   </export>


### PR DESCRIPTION
Fixes a couple of issues with the dependency declarations:

- Removes `run_depend` on `mjpeg_server` from `vulcano_web`. This package no longer exists in kinetic.
- Updates the list of dependencies on the `vulcano_common` metapackage with all packages in repo (except for the `CATKIN_IGNORE`d `vulcano_arm_pad`. It previously contained a dependency on no longer existing `vulcano_pad_description`.

Both issues above were preventing `rosdep` to succeed installing dependencies.